### PR TITLE
fix width, typo and locale

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,3 @@
 .md-grid {
-    max-width: initial; 
-  }
+  max-width: 1600px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,12 @@
 site_name: SS220 SS14 Wiki
 repo_url: https://github.com/SerbiaStrong-220/wiki-14
 repo_name: SerbiaStrong-220/wiki-14
-copyright: Copyright &copy; 2023 SS220. Written and maintained by SS220 comunity
+copyright: Copyright &copy; 2023 SS220. Written and maintained by SS220 community.
 
 theme:
     name: material
     language: ru
+    locale: ru
     palette:
         # Palette toggle for dark mode
         - scheme: slate
@@ -14,7 +15,7 @@ theme:
             name: Switch to light mode
         - scheme: default
           toggle:
-            icon: material/brightness-7 
+            icon: material/brightness-7
             name: Switch to dark mode
 
     features:
@@ -32,7 +33,7 @@ plugins:
 
 extra:
   social:
-    - icon: fontawesome/brands/discord 
+    - icon: fontawesome/brands/discord
       link: https://discord.gg/ss220
 
 extra_css:


### PR DESCRIPTION
Фиксы:
- Максимальная ширина страницы теперь зафиксирована на 1600 пикселях, что дает строку длинной в ~100 символов, что потолок для читабельного текста.
- Выставлена русская локаль, нужно для плагина с датой изменения
- Исправлена опечатка в копирайте